### PR TITLE
Fix button style and bump version number for non-rebuild updating

### DIFF
--- a/assets/javascripts/initializers/toggle-hidedevs.js.es6
+++ b/assets/javascripts/initializers/toggle-hidedevs.js.es6
@@ -39,7 +39,7 @@ export default {
             actions: {
               toggleHideDevs() { // handle the button pressed action.
                 this.toggleProperty('outletArgs.composer.hideDevs');
-                $(".toggle-hide-devs-btn").toggleClass("dis"); // toggle the button "dis" class.
+                $(".toggle-hide-devs-btn").toggleClass("btn-hover"); // toggle the button "btn-hover" class.
               }
             }
           });

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-hide-devs
 # about: Hide developers discourse plugin.
-# version: 2.0
+# version: 2.1
 # authors: CitizenFX Collective & Tom Grobbe
 # url: https://github.com/blattersturm/discourse-hide-devs
 


### PR DESCRIPTION
This fixes the button style since Discourse apparently doesn't style the "dis" class for buttons anymore.